### PR TITLE
Save QUnit test results as HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /Makefile.setupenv
 /cin
 /config/perl/libs.txt
+/test_results/

--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,9 @@ test:
         parallel: true
     - docker kill firefoxdriver:
         parallel: true
+  post:
+    - mkdir $CIRCLE_ARTIFACTS/test_results
+    - mv test_results/* $CIRCLE_ARTIFACTS/test_results
 
 deployment:
   nightly:


### PR DESCRIPTION
On running t/test.t, currently, the QUnit test results are outputted to TAP description only when test failed.　To see test results easily, this pull request changes the test script so that it saves QUnit test result as HTML.

Test results are outputted under `$TEST_RESULTS_DIR` directory (or test_results directory if not specified).

## On CircleCI

Test results are move to `$CIRCLE_ARTIFACT/test_results` directory on CircleCI. So you can see test results on “Artifacts” tab on each build on CircleCI (e.g. https://circleci.com/gh/wakaba/timejs/6#artifacts/containers/0).