### PR TITLE
Fix fractional seconds of `datetime` attribute values

### DIFF
--- a/src/time.js
+++ b/src/time.js
@@ -73,7 +73,7 @@ TER.prototype._setDateTimeAttr = function (el, date) {
   r += 'T' + ('0' + date.getUTCHours ()).slice (-2);
   r += ':' + ('0' + date.getUTCMinutes ()).slice (-2);
   r += ':' + ('0' + date.getUTCSeconds ()).slice (-2);
-  r += '.' + (date.getUTCMilliseconds () + '00').slice (2);
+  r += '.' + (date.getUTCMilliseconds () === 0 ? '0' : ('00' + date.getUTCMilliseconds ()).slice (-3).replace (/0+$/, ''));
   r += 'Z';
   el.setAttribute ('datetime', r);
 }; // TER.prototype._setDateTimeAttr
@@ -91,7 +91,7 @@ TER.prototype._setTimeAttr = function (el, date) {
   r = ('0' + date.getUTCHours ()).slice (-2);
   r += ':' + ('0' + date.getUTCMinutes ()).slice (-2);
   r += ':' + ('0' + date.getUTCSeconds ()).slice (-2);
-  r += '.' + (date.getUTCMilliseconds () + '00').slice (2);
+  r += '.' + (date.getUTCMilliseconds () === 0 ? '0' : ('00' + date.getUTCMilliseconds ()).slice (-3).replace (/0+$/, ''));
   el.setAttribute ('datetime', r);
 }; // TER.prototype._setTimeAttr
 

--- a/src/time.js
+++ b/src/time.js
@@ -51,16 +51,7 @@ TER.prototype._setDateContent = function (el, date) {
 }; // TER.prototype._setDateContent
 
 TER.prototype._setDateTimeAttr = function (el, date) {
-  var r = '';
-  r = date.getUTCFullYear (); // JS does not support years 0001-0999
-  r += '-' + ('0' + (date.getUTCMonth () + 1)).slice (-2);
-  r += '-' + ('0' + date.getUTCDate ()).slice (-2);
-  r += 'T' + ('0' + date.getUTCHours ()).slice (-2);
-  r += ':' + ('0' + date.getUTCMinutes ()).slice (-2);
-  r += ':' + ('0' + date.getUTCSeconds ()).slice (-2);
-  r += '.' + (date.getUTCMilliseconds () === 0 ? '0' : ('00' + date.getUTCMilliseconds ()).slice (-3).replace (/0+$/, ''));
-  r += 'Z';
-  el.setAttribute ('datetime', r);
+  el.setAttribute ('datetime', date.toISOString ());
 }; // TER.prototype._setDateTimeAttr
 
 TER.prototype._setDateAttr = function (el, date) {

--- a/t/time-ter-tests.html
+++ b/t/time-ter-tests.html
@@ -17,7 +17,7 @@
 
     QUnit.test("replace `time` content", function (assert) {
       var testElemIdToExpectedValuesDictionary = {
-        "test-time-1": {
+        "test-dateTime-1": {
           "UTC:en-US": "1/1/2016, 12:00:00 AM",
           "UTC:ja-JP": "2016/1/1 0:00:00",
           "Asia/Tokyo:en-US": "1/1/2016, 9:00:00 AM",
@@ -25,7 +25,7 @@
           "America/Los_Angeles:en-US": "12/31/2015, 4:00:00 PM",
           "America/Los_Angeles:ja-JP": "2015/12/31 16:00:00",
         },
-        "test-time-2": {
+        "test-dateTime-2": {
           "UTC:en-US": "1/1/2016, 11:59:59 AM",
           "UTC:ja-JP": "2016/1/1 11:59:59",
           "Asia/Tokyo:en-US": "1/1/2016, 8:59:59 PM",
@@ -33,7 +33,7 @@
           "America/Los_Angeles:en-US": "1/1/2016, 3:59:59 AM",
           "America/Los_Angeles:ja-JP": "2016/1/1 3:59:59",
         },
-        "test-time-3": {
+        "test-dateTime-3": {
           "UTC:en-US": "1/1/2016, 12:00:00 PM",
           "UTC:ja-JP": "2016/1/1 12:00:00",
           "Asia/Tokyo:en-US": "1/1/2016, 9:00:00 PM",
@@ -41,7 +41,7 @@
           "America/Los_Angeles:en-US": "1/1/2016, 4:00:00 AM",
           "America/Los_Angeles:ja-JP": "2016/1/1 4:00:00",
         },
-        "test-time-4": {
+        "test-dateTime-4": {
           "UTC:en-US": "1/1/2016, 12:00:01 PM",
           "UTC:ja-JP": "2016/1/1 12:00:01",
           "Asia/Tokyo:en-US": "1/1/2016, 9:00:01 PM",
@@ -49,7 +49,7 @@
           "America/Los_Angeles:en-US": "1/1/2016, 4:00:01 AM",
           "America/Los_Angeles:ja-JP": "2016/1/1 4:00:01",
         },
-        "test-time-5": {
+        "test-dateTime-5": {
           "UTC:en-US": "1/1/2016, 11:59:59 PM",
           "UTC:ja-JP": "2016/1/1 23:59:59",
           "Asia/Tokyo:en-US": "1/2/2016, 8:59:59 AM",
@@ -57,7 +57,7 @@
           "America/Los_Angeles:en-US": "1/1/2016, 3:59:59 PM",
           "America/Los_Angeles:ja-JP": "2016/1/1 15:59:59",
         },
-        "test-time-6": {
+        "test-dateTime-with-offset-1": {
           "UTC:en-US": "1/1/2016, 3:00:00 AM",
           "UTC:ja-JP": "2016/1/1 3:00:00",
           "Asia/Tokyo:en-US": "1/1/2016, 12:00:00 PM",
@@ -65,10 +65,102 @@
           "America/Los_Angeles:en-US": "12/31/2015, 7:00:00 PM",
           "America/Los_Angeles:ja-JP": "2015/12/31 19:00:00",
         },
+
+        "test-date-1": {
+          "UTC:en-US": "1/1/1000",
+          "UTC:ja-JP": "1000/1/1",
+          "Asia/Tokyo:en-US": "1/1/1000",
+          "Asia/Tokyo:ja-JP": "1000/1/1",
+          "America/Los_Angeles:en-US": "1/1/1000",
+          "America/Los_Angeles:ja-JP": "1000/1/1",
+        },
+        "test-date-2": {
+          "UTC:en-US": "12/31/1999",
+          "UTC:ja-JP": "1999/12/31",
+          "Asia/Tokyo:en-US": "12/31/1999",
+          "Asia/Tokyo:ja-JP": "1999/12/31",
+          "America/Los_Angeles:en-US": "12/31/1999",
+          "America/Los_Angeles:ja-JP": "1999/12/31",
+        },
+        "test-date-after-y10k-1": {
+          "UTC:en-US": "1/1/10000",
+          "UTC:ja-JP": "10000/1/1",
+          "Asia/Tokyo:en-US": "1/1/10000",
+          "Asia/Tokyo:ja-JP": "10000/1/1",
+          "America/Los_Angeles:en-US": "1/1/10000",
+          "America/Los_Angeles:ja-JP": "10000/1/1",
+        },
+        "test-date-after-y10k-2": {
+          "UTC:en-US": "1/1/100000",
+          "UTC:ja-JP": "100000/1/1",
+          "Asia/Tokyo:en-US": "1/1/100000",
+          "Asia/Tokyo:ja-JP": "100000/1/1",
+          "America/Los_Angeles:en-US": "1/1/100000",
+          "America/Los_Angeles:ja-JP": "100000/1/1",
+        },
+
+        "test-time-1": {
+          "UTC:en-US": "1:20:34 AM",
+          "UTC:ja-JP": "1:20:34",
+          "Asia/Tokyo:en-US": "1:20:34 AM",
+          "Asia/Tokyo:ja-JP": "1:20:34",
+          "America/Los_Angeles:en-US": "1:20:34 AM",
+          "America/Los_Angeles:ja-JP": "1:20:34",
+        },
+        "test-time-2": {
+          "UTC:en-US": "12:34:56 PM",
+          "UTC:ja-JP": "12:34:56",
+          "Asia/Tokyo:en-US": "12:34:56 PM",
+          "Asia/Tokyo:ja-JP": "12:34:56",
+          "America/Los_Angeles:en-US": "12:34:56 PM",
+          "America/Los_Angeles:ja-JP": "12:34:56",
+        },
+        "test-time-3": {
+          "UTC:en-US": "11:59:59 PM",
+          "UTC:ja-JP": "23:59:59",
+          "Asia/Tokyo:en-US": "11:59:59 PM",
+          "Asia/Tokyo:ja-JP": "23:59:59",
+          "America/Los_Angeles:en-US": "11:59:59 PM",
+          "America/Los_Angeles:ja-JP": "23:59:59",
+        },
+        "test-time-without-seconds-1": {
+          "UTC:en-US": "11:59:00 PM",
+          "UTC:ja-JP": "23:59:00",
+          "Asia/Tokyo:en-US": "11:59:00 PM",
+          "Asia/Tokyo:ja-JP": "23:59:00",
+          "America/Los_Angeles:en-US": "11:59:00 PM",
+          "America/Los_Angeles:ja-JP": "23:59:00",
+        },
+        "test-time-with-milliseconds-1": {
+          "UTC:en-US": "1:20:30 PM",
+          "UTC:ja-JP": "13:20:30",
+          "Asia/Tokyo:en-US": "1:20:30 PM",
+          "Asia/Tokyo:ja-JP": "13:20:30",
+          "America/Los_Angeles:en-US": "1:20:30 PM",
+          "America/Los_Angeles:ja-JP": "13:20:30",
+        },
       };
       Object.keys(testElemIdToExpectedValuesDictionary).forEach(function (testElemId) {
         var expectedValues = testElemIdToExpectedValuesDictionary[testElemId];
         assert.equal(document.getElementById(testElemId).textContent, expectedValues[envKey]);
+      });
+    });
+
+    QUnit.test("The `datetime` attribute should be set", function (assert) {
+      var testElemIdToExpectedValuesDictionary = {
+        "test-dateTime-2": "2016-01-01T11:59:59.0Z",
+        "test-dateTime-with-offset-1": "2016-01-01T03:00:00.0Z",
+
+        "test-date-2": "1999-12-31",
+        "test-date-after-y10k-1": "10000-01-01",
+
+        "test-time-1": "01:20:34.0",
+        "test-time-with-milliseconds-1": "13:20:30.300", // Bug
+      };
+      Object.keys(testElemIdToExpectedValuesDictionary).forEach(function (testElemId) {
+        var dateTimeAttr = document.getElementById (testElemId).getAttribute ("datetime");
+        var expectedValue = testElemIdToExpectedValuesDictionary[testElemId];
+        assert.equal (dateTimeAttr, expectedValue);
       });
     });
   </script>
@@ -76,12 +168,23 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture">
-    <time id="test-time-1">2016-01-01T00:00:00Z</time>
-    <time id="test-time-2">2016-01-01T11:59:59Z</time>
-    <time id="test-time-3">2016-01-01T12:00:00Z</time>
-    <time id="test-time-4">2016-01-01T12:00:01Z</time>
-    <time id="test-time-5">2016-01-01T23:59:59Z</time>
-    <time id="test-time-6">2016-01-01T12:00:00+09:00</time>
+    <time id="test-dateTime-1">2016-01-01T00:00:00Z</time>
+    <time id="test-dateTime-2">2016-01-01T11:59:59Z</time>
+    <time id="test-dateTime-3">2016-01-01T12:00:00Z</time>
+    <time id="test-dateTime-4">2016-01-01T12:00:01Z</time>
+    <time id="test-dateTime-5">2016-01-01T23:59:59Z</time>
+    <time id="test-dateTime-with-offset-1">2016-01-01T12:00:00+09:00</time>
+
+    <time id="test-date-1">1000-01-01</time>
+    <time id="test-date-2">1999-12-31</time>
+    <time id="test-date-after-y10k-1">10000-01-01</time>
+    <time id="test-date-after-y10k-2">100000-01-01</time>
+
+    <time id="test-time-1">01:20:34</time>
+    <time id="test-time-2">12:34:56</time>
+    <time id="test-time-3">23:59:59</time>
+    <time id="test-time-without-seconds-1">23:59</time>
+    <time id="test-time-with-milliseconds-1">13:20:30.123</time>
   </div>
 </body>
 </html>

--- a/t/time-ter-tests.html
+++ b/t/time-ter-tests.html
@@ -150,17 +150,17 @@
       var testElemIdToExpectedValuesDictionary = {
         "test-dateTime-2": "2016-01-01T11:59:59.0Z",
         "test-dateTime-with-offset-1": "2016-01-01T03:00:00.0Z",
-        "test-dateTime-with-milliseconds-1": "2016-01-01T00:00:00.300Z", // Bug
-        "test-dateTime-with-milliseconds-2": "2016-01-01T00:00:00.0Z", // Bug?
-        "test-dateTime-with-milliseconds-3": "2016-01-01T00:00:00.00Z", // Bug
+        "test-dateTime-with-milliseconds-1": "2016-01-01T00:00:00.123Z",
+        "test-dateTime-with-milliseconds-2": "2016-01-01T00:00:00.005Z",
+        "test-dateTime-with-milliseconds-3": "2016-01-01T00:00:00.05Z",
 
         "test-date-2": "1999-12-31",
         "test-date-after-y10k-1": "10000-01-01",
 
         "test-time-1": "01:20:34.0",
-        "test-time-with-milliseconds-1": "13:20:30.300", // Bug
-        "test-time-with-milliseconds-2": "13:20:30.0", // Bug?
-        "test-time-with-milliseconds-3": "13:20:30.00", // Bug
+        "test-time-with-milliseconds-1": "13:20:30.123",
+        "test-time-with-milliseconds-2": "13:20:30.005",
+        "test-time-with-milliseconds-3": "13:20:30.05",
       };
       Object.keys(testElemIdToExpectedValuesDictionary).forEach(function (testElemId) {
         var dateTimeAttr = document.getElementById (testElemId).getAttribute ("datetime");

--- a/t/time-ter-tests.html
+++ b/t/time-ter-tests.html
@@ -150,12 +150,17 @@
       var testElemIdToExpectedValuesDictionary = {
         "test-dateTime-2": "2016-01-01T11:59:59.0Z",
         "test-dateTime-with-offset-1": "2016-01-01T03:00:00.0Z",
+        "test-dateTime-with-milliseconds-1": "2016-01-01T00:00:00.300Z", // Bug
+        "test-dateTime-with-milliseconds-2": "2016-01-01T00:00:00.0Z", // Bug?
+        "test-dateTime-with-milliseconds-3": "2016-01-01T00:00:00.00Z", // Bug
 
         "test-date-2": "1999-12-31",
         "test-date-after-y10k-1": "10000-01-01",
 
         "test-time-1": "01:20:34.0",
         "test-time-with-milliseconds-1": "13:20:30.300", // Bug
+        "test-time-with-milliseconds-2": "13:20:30.0", // Bug?
+        "test-time-with-milliseconds-3": "13:20:30.00", // Bug
       };
       Object.keys(testElemIdToExpectedValuesDictionary).forEach(function (testElemId) {
         var dateTimeAttr = document.getElementById (testElemId).getAttribute ("datetime");
@@ -174,6 +179,9 @@
     <time id="test-dateTime-4">2016-01-01T12:00:01Z</time>
     <time id="test-dateTime-5">2016-01-01T23:59:59Z</time>
     <time id="test-dateTime-with-offset-1">2016-01-01T12:00:00+09:00</time>
+    <time id="test-dateTime-with-milliseconds-1">2016-01-01T00:00:00.123Z</time>
+    <time id="test-dateTime-with-milliseconds-2">2016-01-01T00:00:00.005Z</time>
+    <time id="test-dateTime-with-milliseconds-3">2016-01-01T00:00:00.050Z</time>
 
     <time id="test-date-1">1000-01-01</time>
     <time id="test-date-2">1999-12-31</time>
@@ -185,6 +193,8 @@
     <time id="test-time-3">23:59:59</time>
     <time id="test-time-without-seconds-1">23:59</time>
     <time id="test-time-with-milliseconds-1">13:20:30.123</time>
+    <time id="test-time-with-milliseconds-2">13:20:30.005</time>
+    <time id="test-time-with-milliseconds-3">13:20:30.050</time>
   </div>
 </body>
 </html>

--- a/t/time-ter-tests.html
+++ b/t/time-ter-tests.html
@@ -107,11 +107,11 @@
 
     QUnit.test("The `datetime` attribute should be set", function (assert) {
       var testElemIdToExpectedValuesDictionary = {
-        "test-dateTime-2": "2016-01-01T11:59:59.0Z",
-        "test-dateTime-with-offset-1": "2016-01-01T03:00:00.0Z",
+        "test-dateTime-2": "2016-01-01T11:59:59.000Z",
+        "test-dateTime-with-offset-1": "2016-01-01T03:00:00.000Z",
         "test-dateTime-with-milliseconds-1": "2016-01-01T00:00:00.123Z",
         "test-dateTime-with-milliseconds-2": "2016-01-01T00:00:00.005Z",
-        "test-dateTime-with-milliseconds-3": "2016-01-01T00:00:00.05Z",
+        "test-dateTime-with-milliseconds-3": "2016-01-01T00:00:00.050Z",
 
         "test-date-2": "1999-12-31",
         "test-date-after-y10k-1": "10000-01-01",


### PR DESCRIPTION
## Problem

* When time.js set a `datetime` attribute to a `time` element, the fractional seconds string misses the original value.
  * E.g. Assuming the target element is `<time>20:00:00.123</time>`, then the `datetime` attribute which is set by time.js is `20:00:00.3`

## Changes

* Fix the problem.
  * Use `Date.prototype.toISOString` method.
* Add tests : 
  * Tests of `datetime` attributes, and
  * Tests of date strings.