### PR TITLE
Use the `options` parameter of `Date.prototype.toLocaleDateString` method to set date content

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright 2008-2017 Wakaba <wakaba@suikawiki.org>.  All rights reserved.
+Copyright 2017 Hatena <http://hatenacorp.jp/>.  All rights reserved.
 
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2008-2015 Wakaba <wakaba@suikawiki.org>.  All rights reserved.
+Copyright 2008-2017 Wakaba <wakaba@suikawiki.org>.  All rights reserved.
 
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
@@ -36,6 +36,7 @@ the Initial Developer. All Rights Reserved.
 
 Contributor(s):
   Wakaba <wakaba@suikawiki.org>
+  Hatena <http://hatenacorp.jp/>
 
 Alternatively, the contents of this file may be used under the terms of
 either the GNU General Public License Version 2 or later (the "GPL"), or

--- a/src/time.js
+++ b/src/time.js
@@ -106,7 +106,9 @@ TER.prototype._getDate = function (el) {
     if (m[1] < 100) {
       return new Date (NaN);
     }
-    var d = new Date (Date.UTC (m[1], m[2] - 1, m[3], 0, 0, 0));
+    // For old browsers (which don't support the options parameter of `toLocaleDateString` method)
+    // the time value is set to 12:00, so that most cases are covered.
+    var d = new Date (Date.UTC (m[1], m[2] - 1, m[3], 12, 0, 0));
     if (m[1] != d.getUTCFullYear () ||
         m[2] != d.getUTCMonth () + 1 ||
         m[3] != d.getUTCDate ()) {

--- a/src/time.js
+++ b/src/time.js
@@ -47,7 +47,7 @@ TER.prototype._setDateTimeContent = function (el, date) {
 }; // TER.prototype._setDateTimeContent
 
 TER.prototype._setDateContent = function (el, date) {
-  this._setTextContent (el, this._getLocal (date).toLocaleDateString ());
+  this._setTextContent (el, date.toLocaleDateString (navigator.language, {"timeZone": "UTC"}));
 }; // TER.prototype._setDateContent
 
 TER.prototype._setDateTimeAttr = function (el, date) {
@@ -61,13 +61,6 @@ TER.prototype._setDateAttr = function (el, date) {
   r += '-' + ('0' + date.getUTCDate ()).slice (-2);
   el.setAttribute ('datetime', r);
 }; // TER.prototype._setDateAttr
-
-TER.prototype._getLocal = function (d) {
-  /* Return a Date with same numbers of date/time, but in local timezone */
-  return new Date (d.getUTCFullYear (), d.getUTCMonth (), d.getUTCDate (),
-      d.getUTCHours (), d.getUTCMinutes (), d.getUTCSeconds (),
-      d.getUTCMilliseconds ());
-}; // TER.prototype._getLocal
 
 TER.prototype._getDate = function (el) {
   var datetime = el.getAttribute ('datetime');
@@ -325,7 +318,7 @@ is a willful violation to the current HTML Living Standard.
 */
 
 /* ***** BEGIN LICENSE BLOCK *****
- * Copyright 2008-2015 Wakaba <wakaba@suikawiki.org>.  All rights reserved.
+ * Copyright 2008-2017 Wakaba <wakaba@suikawiki.org>.  All rights reserved.
  *
  * This program is free software; you can redistribute it and/or 
  * modify it under the same terms as Perl itself.
@@ -363,6 +356,7 @@ is a willful violation to the current HTML Living Standard.
  *
  * Contributor(s):
  *   Wakaba <wakaba@suikawiki.org>
+ *   Hatena <http://hatenacorp.jp/>
  *
  * Alternatively, the contents of this file may be used under the terms of
  * either the GNU General Public License Version 2 or later (the "GPL"), or

--- a/src/time.js
+++ b/src/time.js
@@ -321,6 +321,7 @@ is a willful violation to the current HTML Living Standard.
 
 /* ***** BEGIN LICENSE BLOCK *****
  * Copyright 2008-2017 Wakaba <wakaba@suikawiki.org>.  All rights reserved.
+ * Copyright 2017 Hatena <http://hatenacorp.jp/>.  All rights reserved.
  *
  * This program is free software; you can redistribute it and/or 
  * modify it under the same terms as Perl itself.


### PR DESCRIPTION
## Problem

There is the problem that a wrong date string can be shown in the previous way.

E.g. `<time>1912-01-01</time>` shows `1911-12-31` in the time zone Asia/Seoul.

## Cause

The reason is that there are the time zones in which past offsets and current offsets are different.

For example, the time offset of Korea was changed from UTC+08:30 to UTC+09:00 in 1912. So that in that time zone,

* `new Date(1912, 0, 1).toLocaleDateString()` results in `"1911/12/31"` while
* `new Date(1913, 0, 1).toLocaleDateString()` results in `"1913/01/01"`.

## The way to fix

To fix this problem, a second parameter of `Date.prototype.toLocaleDateString` method is used.

* [ECMA-402 (1st)](http://www.ecma-international.org/ecma-402/1.0/#sec-13.3.2)

This way was proposed by @wakaba. 

### Check test on several user agents

#### PC

To check that way can be used or not on each user agent, I used my PC (Windows 10) and [browserling](https://www.browserling.com/internet-explorer-testing), which provides several user agents through the web browser. Test code is [https://jsfiddle.net/wdem535u/4/](https://jsfiddle.net/wdem535u/4/).

* Windows 10, Edge 40.15063.0.0 : OK
* Windows 10, IE 11.0.42 : OK
* Windows 10, Firefox 53.0.3 : OK
* Windows 7, Safari 5.1 : **NG (it shows `Monday, December 30, 999`)**
* Windows 7, Chrome 58 : OK (it shows `1/1/1000`)
* Windows Vista, IE 9 : OK (it shows `1/1/1000`)
* Windows Vista, Opera 36 : OK (it shows `1/1/1000`)

Safari 5.1 is too old, so I think it's not problem that Safari 5.1 can't handle this way.

#### Mobile

According to [MDN's `Date#toLocaleDateString` page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString), most mobile browsers doesn't support locales and options parameters of `Date.prototype.toLocaleDateString`. (Only Chrome for Android 26+ and Safari Mobile 10+ do.)

I think this is problem.