### PR TITLE
Update the way to specify Firefox locale for tests

### DIFF
--- a/t/run-wd-tests.sh
+++ b/t/run-wd-tests.sh
@@ -14,14 +14,14 @@ esac
 
 # Notes
 # * On Firefox,
-#   * `Date.prototype.toLocaleString` method depends on locale of OS, and
+#   * `Date.prototype.toLocaleString` method depends on `intl.locale.requested` of prefs, and
 #   * `navigator.language` depends on `intl.accept_languages` of prefs.
 case $WD_LOCALE in
   "en-US") name_locale="en" ; wd_lang_env="en_US.utf-8" ; test_lang="en-US" ;
-    test_wd_desired_capabilities='{ "moz:firefoxOptions": { "prefs": { "intl.accept_languages": "en-US, en" } } }'
+    test_wd_desired_capabilities='{ "moz:firefoxOptions": { "prefs": { "intl.locale.requested": "en-US", "intl.accept_languages": "en-US, en" } } }'
     ;;
   "ja-JP") name_locale="ja" ; wd_lang_env="ja_JP.utf-8" ; test_lang="ja-JP" ;
-    test_wd_desired_capabilities='{ "moz:firefoxOptions": { "prefs": { "intl.accept_languages": "ja-JP, en-US, en" } } }'
+    test_wd_desired_capabilities='{ "moz:firefoxOptions": { "prefs": { "intl.locale.requested": "ja-JP", "intl.accept_languages": "ja-JP, en-US, en" } } }'
     ;;
   *) echo "Unknown \$WD_LOCALE: $WD_LOCALE"; exit 1 ;;
 esac


### PR DESCRIPTION
In Firefox 59 or later, JS context locale is tied to Firefox locale, and requested Firefox locale is specified with `intl.locale.requested` pref.

* See : https://firefox-source-docs.mozilla.org/intl/locale.html